### PR TITLE
split technician dashboard to Open Requests and My Work Orders

### DIFF
--- a/my-app/src/app/page.tsx
+++ b/my-app/src/app/page.tsx
@@ -54,6 +54,7 @@ export default function Home() {
   const [category, setCategory] = useState("")
   const [categoriesList, setCategoriesList] = useState<Array<{id:number, slug:string, name:string}>>([])
   const [date, setDate] = useState<string>("")
+  const [activeTab, setActiveTab] = useState<"open" | "mine">("open")
 
   // load role once and on auth changes
   useEffect(() => {
@@ -341,8 +342,17 @@ export default function Home() {
     setLoading(false)
   }
 
-  // derived lists
-  const filteredOrders = orders.filter((o) => {
+  // derived lists: first filter by active tab, then by search/filters
+  const tabFiltered = orders.filter((o) => {
+    if (activeTab === "open") {
+      // Open Requests: status === "open" and not assigned
+      return (o.status || "").toLowerCase() === "open" && !o.assigned_to
+    }
+    // My Work Orders: assigned to current user
+    return currentUserId ? o.assigned_to === currentUserId : false
+  })
+
+  const filteredOrders = tabFiltered.filter((o) => {
     if (search) {
       const hay = ((o.title || "") + " " + (o.description || "") + " " + (o.labName || "")).toLowerCase()
       if (!hay.includes(search.toLowerCase())) return false
@@ -351,6 +361,19 @@ export default function Home() {
     if (selectedCategory && o.category_id !== selectedCategory) return false
     return true
   })
+
+  // ensure selectedId points to a visible item when filters/tabs change
+  useEffect(() => {
+    if (!filteredOrders.length) {
+      setSelectedId(null)
+      return
+    }
+    if (!selectedId || !filteredOrders.find((f) => f.id === selectedId)) {
+      setSelectedId(filteredOrders[0].id)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeTab, orders, search, selectedLab, selectedCategory])
+
   const selectedOrder = orders.find((o) => o.id === selectedId) ?? (filteredOrders[0] ?? null)
 
   // wait for role load
@@ -366,16 +389,32 @@ export default function Home() {
             <AuthStatus />
           </header>
 
+          {/* Tabs */}
+          <div className="mb-4 flex items-center gap-3">
+            <button
+              onClick={() => setActiveTab("open")}
+              className={`px-4 py-2 rounded-full ${activeTab === "open" ? "bg-green-600 text-white" : "bg-gray-100 text-gray-700"}`}
+            >
+              Open Requests
+            </button>
+            <button
+              onClick={() => setActiveTab("mine")}
+              className={`px-4 py-2 rounded-full ${activeTab === "mine" ? "bg-green-600 text-white" : "bg-gray-100 text-gray-700"}`}
+            >
+              My Work Orders
+            </button>
+          </div>
+
           {/* Filter bar */}
-          <section className="space-y-6">
+           <section className="space-y-6">
             <div className="rounded-xl bg-gray-50 p-4 flex gap-3 items-center">
-              <input
-                type="search"
-                placeholder="Search Request"
-                value={search}
-                onChange={(e) => setSearch(e.target.value)}
-                className="flex-1 px-4 py-3 border rounded-lg bg-white"
-              />
+               <input
+                 type="search"
+                 placeholder="Search Request"
+                 value={search}
+                 onChange={(e) => setSearch(e.target.value)}
+                 className="flex-1 px-4 py-3 border rounded-lg bg-white"
+               />
 
               <select
                 value={selectedLab ?? ""}


### PR DESCRIPTION
Added two different tabs on the top of the technician homepage. 'Open Requests' tab and 'My Work Orders' tab. Open Requests tab shows all work orders that are in 'open' status. For My Work Orders tab, it shows all work orders that are assigned to the current user (technician). This includes past, cancelled, claimed  work orders.